### PR TITLE
Fix logic validator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           for file in **/*.logic; do
             echo "$file... ";
             status=0
-            cat "$file" | (rando-shuffler/target/debug/rando_shuffler > /dev/null) || status=1
+            cat "$file" | rando-shuffler/target/debug/rando_shuffler || status=1
             if [[ $status != 0 ]]; then
               failed=1;
             else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,20 @@ jobs:
       - name: Run the shuffler
         run: |
           shopt -s globstar
+          failed=0;
           for file in **/*.logic; do
-            cat "$file" | rando-shuffler/target/debug/rando_shuffler
+            echo "$file... ";
+            status=0
+            cat "$file" | (rando-shuffler/target/debug/rando_shuffler > /dev/null) || status=1
+            if [[ $status != 0 ]]; then
+              failed=1;
+            else
+              echo " PASSED";
+            fi
+            echo "-------------------------------"
+            echo ""
           done;
+          if [[ $failed != 0 ]]; then
+            exit 1;
+          fi
+


### PR DESCRIPTION
Currently, as soon as one file fails validation the CI job exits and reports failure. This makes it so the logic validator runs for every file before reporting a failure.

Closes #6 