### PR TITLE
Remove rando-shuffler test files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run the shuffler
         run: |
           shopt -s globstar
-          rm -f rando-shuffler/*.logic  # remove test files
+          find rando-shuffler/ -name "*.logic" -type f -delete # remove test files
           file_count=0
           failed=0;
           for file in **/*.logic; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Run the shuffler
         run: |
           shopt -s globstar
+          rm -f rando-shuffler/*.logic  # remove test files
           failed=0;
           for file in **/*.logic; do
             echo "$file... ";

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,20 +64,22 @@ jobs:
         run: |
           shopt -s globstar
           rm -f rando-shuffler/*.logic  # remove test files
+          file_count=0
           failed=0;
           for file in **/*.logic; do
             echo "$file... ";
             status=0
             cat "$file" | rando-shuffler/target/debug/rando_shuffler || status=1
             if [[ $status != 0 ]]; then
-              failed=1;
+              failed=$((failed + 1));
             else
               echo " PASSED";
             fi
             echo "-------------------------------"
             echo ""
+            file_count=$((file_count + 1))
           done;
+          echo "RESULTS: $((file_count - failed)) / $file_count passed"
           if [[ $failed != 0 ]]; then
             exit 1;
           fi
-


### PR DESCRIPTION
The `rando-shuffler` repo contains some test .logic files, which we don't want to include in our test runs.