### PR TITLE
Add island shop items

### DIFF
--- a/SE Sea/Goron Island/Goron.logic
+++ b/SE Sea/Goron Island/Goron.logic
@@ -22,6 +22,8 @@ area GoronIsland:
   room GoronShop:
     node Main:
       door Outside
+      chest BombchuBagUpgrade
+      chest RandomTreasure
 
   room OneRockSmallGoronHouse:
     node Main:

--- a/SW Sea/Mercay Island/Mercay.logic
+++ b/SW Sea/Mercay Island/Mercay.logic
@@ -48,6 +48,10 @@ area Mercay:
   room MercayShop:
     node Main:
       door Outside
+      chest WoodenShield
+      chest PowerGem
+      chest QuiverUpgrade
+      chest RandomTreasure
 
   room Tavern:
     node Main:

--- a/SW Sea/Molida Island/Molida.logic
+++ b/SW Sea/Molida Island/Molida.logic
@@ -3,7 +3,7 @@ area Molida:
     node Main:
       door LeftmostHouse
       door MiddleHouse
-      door MolidaSHop
+      door MolidaShop
       door RomanoHouse
 
     node Hole: entrance HoleToCave
@@ -45,6 +45,13 @@ area Molida:
   room MiddleHouse:
     node Main: 
       door Outside
+
+  room MolidaShop:
+    node Main:
+      door Outside
+      chest WoodenShield
+      chest QuiverUpgrade
+      chest RandomTreasure
 
   room CaveSystem:
 


### PR DESCRIPTION
Adds randomizable items from the three island shops (Mercay, Molida, and Goron islands).